### PR TITLE
Update blockquote.scss

### DIFF
--- a/src/tags/blockquote.scss
+++ b/src/tags/blockquote.scss
@@ -24,7 +24,7 @@ blockquote {
 
   & > :first-child {
     margin-top: 0;
-    text-indent: 1rem;
+    text-indent: 1.75rem;
   }
 
   & > :last-child {


### PR DESCRIPTION
The first-child of blockquote with text-indent: 1rem overlaps the blockquote::before 'open-quote' content. 
To address this issue, I propose changing the text-indent to 1.75rem for the first-child of blockquote.

![image](https://user-images.githubusercontent.com/25039646/156526320-ee90de1e-6fa0-48f5-af0f-661f6264093b.png)
![image](https://user-images.githubusercontent.com/25039646/156526384-bfdf68ea-416f-490f-ad0b-adb7ff387064.png)
