### PR TITLE
Fixed typo "breask" to breaks on Inline Elements

### DIFF
--- a/demo/pages/inline-elements.html
+++ b/demo/pages/inline-elements.html
@@ -9,7 +9,7 @@
     <strike>strike</strike>), and the <code>&lt;u&gt;</code> tag now stands for
     <u>unarticullated-text</u> instead of underline; abbreviations are great, as you may have
     <abbr title="too many abbreviations">TMA</abbr>; <code>inline code</code> is cool too;
-    You can also add line breask with br...<br />
+    You can also add line breaks with br...<br />
     <mark>Highlight text with mark</mark> or display a <kbd>Key</kbd>. You can also have
     <q>inline quotes with q</q>, or <samp>results from an operation with samp</samp> or a
     <var>variable</var>, or an <output>output</output>, also there's <small>small text</small>, text
@@ -29,7 +29,7 @@ you can &lt;s&gt;strikethrough text&lt;/s&gt; (or use the deprecated tag in HTML
 &lt;strike&gt;strike&lt;/strike&gt;), and the &lt;code&gt;&lt;u&gt;&lt;/code&gt; tag now stands for
 &lt;u&gt;unarticullated-text&lt;/u&gt; instead of underline; abbreviations are great, as you may have
 &lt;abbr title="too many abbreviations"&gt;TMA&lt;/abbr&gt;; &lt;code&gt;inline code&lt;/code&gt; is cool too;
-You can also add line breask with br...&lt;br /&gt;
+You can also add line breaks with br...&lt;br /&gt;
 &lt;mark&gt;Highlight text with mark&lt;/mark&gt; or display a &lt;kbd&gt;Key&lt;/kbd&gt;. You can also have
 &lt;q&gt;inline quotes with q&lt;/q&gt;, or &lt;samp&gt;results from an operation with samp&lt;/samp&gt; or a
 &lt;var&gt;variable&lt;/var&gt;, or an &lt;output&gt;output&lt;/output&gt;, also there's &lt;small&gt;small text&lt;/small&gt;, text


### PR DESCRIPTION
Simple typo in the inline elements page fixed. Went from "breask" when talking about line break tags to "breaks"