### PR TITLE
Fix inconsistencies with disabled form elements

### DIFF
--- a/src/general/inputs.scss
+++ b/src/general/inputs.scss
@@ -194,6 +194,9 @@ input[type="checkbox"] {
   &:disabled {
     box-shadow: inset 0 0 0 0.185rem var(--secondary-lighter);
     background: var(--secondary-lighter);
+    &:checked {
+      background: var(--secondary-light);
+    }
   }
 }
 

--- a/src/general/inputs.scss
+++ b/src/general/inputs.scss
@@ -30,7 +30,7 @@ select {
 
   &[disabled],
   &:disabled {
-    background: var(--secondary-lighter);
+    background-color: var(--secondary-lighter);
     color: var(--secondary-light);
   }
 

--- a/src/general/inputs.scss
+++ b/src/general/inputs.scss
@@ -201,7 +201,7 @@ input[type="checkbox"] {
 }
 
 // select
-select:not([multiple]):not([disabled]) {
+select:not([multiple]):not([disabled]):not(:disabled) {
   -webkit-appearance: none;
   appearance: none;
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><path d='M0,10 20,30 40,10' fill='none' stroke='%23999' stroke-width='2'/></svg>");


### PR DESCRIPTION
![almond-fix-disabled](https://github.com/alvaromontoro/almond.css/assets/719105/4c0e28be-4396-420b-a81d-3f174a353fe4)

This PR fixes three things I found odd with how disabled form elements are rendered:

- Icons were hidden (due to the background color being set using `background`, which overwrote `background-image` as well)
- Checked radio controls and checkboxes were indistinguishable from unchecked ones
- The background color for select elements was inconsistent

I've added some notes in the actual commits, if you want me to squash it into one commit or include the changes to `dist/`, please let me know.