### PR TITLE
fix: icon disappearing on disabled inputs

### DIFF
--- a/src/general/inputs.scss
+++ b/src/general/inputs.scss
@@ -30,7 +30,7 @@ select {
 
   &[disabled],
   &:disabled {
-    background: var(--secondary-lighter);
+    background-color: var(--secondary-lighter);
     color: var(--secondary-light);
   }
 


### PR DESCRIPTION
Input type icon is disappearing when the element is disabled, since the `backround` property is set to `--secondary-lighter`, instead of `background-color`.